### PR TITLE
ros2_intel_realsense: 2.0.7-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1340,18 +1340,18 @@ repositories:
   librealsense:
     doc:
       type: git
-      url: https://github.com/IntelRealSense/librealsense.git
+      url: https://github.com/sharronliu/librealsense.git
       version: ros2debian
     release:
       packages:
       - librealsense2
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.16.5-1
+      url: https://github.com/sharronliu/librealsense-release.git
+      version: v2.34.0-ros2
     source:
       type: git
-      url: https://github.com/IntelRealSense/librealsense.git
+      url: https://github.com/sharronliu/librealsense.git
       version: ros2debian
     status: maintained
   libyaml_vendor:
@@ -2360,20 +2360,20 @@ repositories:
   ros2_intel_realsense:
     doc:
       type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: master
+      url: https://github.com/sharronliu/ros2_intel_realsense.git
+      version: refactor
     release:
       packages:
       - realsense_camera_msgs
       - realsense_ros2_camera
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.4-2
+      url: https://github.com/sharronliu/ros2_intel_realsense-release.git
+      version: 2.0.7
     source:
       type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: master
+      url: https://github.com/sharronliu/ros2_intel_realsense.git
+      version: refactor
     status: maintained
   ros2_object_analytics:
     doc:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1340,18 +1340,18 @@ repositories:
   librealsense:
     doc:
       type: git
-      url: https://github.com/IntelRealSense/librealsense.git
+      url: https://github.com/sharronliu/librealsense.git
       version: ros2debian
     release:
       packages:
       - librealsense2
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.16.5-1
+      url: https://github.com/sharronliu/librealsense-release.git
+      version: v2.34.0-ros2
     source:
       type: git
-      url: https://github.com/IntelRealSense/librealsense.git
+      url: https://github.com/sharronliu/librealsense.git
       version: ros2debian
     status: maintained
   libyaml_vendor:
@@ -2360,20 +2360,22 @@ repositories:
   ros2_intel_realsense:
     doc:
       type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: master
+      url: https://github.com/sharronliu/ros2_intel_realsense.git
+      version: refactor
     release:
       packages:
-      - realsense_camera_msgs
-      - realsense_ros2_camera
+      - realsense_msgs
+      - realsense_ros
+      - realsense_node
+      - realsense_examples
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.4-2
+      url: https://github.com/sharronliu/ros2_intel_realsense-release.git
+      version: 2.0.7
     source:
       type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: master
+      url: https://github.com/sharronliu/ros2_intel_realsense.git
+      version: refactor
     status: maintained
   ros2_object_analytics:
     doc:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2364,14 +2364,14 @@ repositories:
       version: refactor
     release:
       packages:
-      - realsense_msgs
-      - realsense_ros
-      - realsense_node
       - realsense_examples
+      - realsense_msgs
+      - realsense_node
+      - realsense_ros
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.7
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/intel/ros2_intel_realsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_intel_realsense` to `2.0.7-1`:

- upstream repository: https://github.com/intel/ros2_intel_realsense.git
- release repository: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.0.7`
